### PR TITLE
chore: ensure apps depend on types

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adlign/types": "0.1.0",
     "@sentry/node": "^7.0.0",
     "@sentry/profiling-node": "^1.0.0",
     "@supabase/supabase-js": "^2.38.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@adlign/types": "0.1.0",
     "@hookform/resolvers": "^3.3.2",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/apps/worker-mapping/package.json
+++ b/apps/worker-mapping/package.json
@@ -16,6 +16,7 @@
     "test:env": "tsx src/test-env.ts"
   },
   "dependencies": {
+    "@adlign/types": "0.1.0",
     "@sentry/node": "^10.3.0",
     "dotenv": "^16.3.1",
     "openai": "^4.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "name": "@adlign/backend",
       "version": "0.1.0",
       "dependencies": {
+        "@adlign/types": "0.1.0",
         "@sentry/node": "^7.0.0",
         "@sentry/profiling-node": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
@@ -167,6 +168,7 @@
       "name": "@adlign/web",
       "version": "0.0.0",
       "dependencies": {
+        "@adlign/types": "0.1.0",
         "@hookform/resolvers": "^3.3.2",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -210,6 +212,7 @@
       "name": "@adlign/worker-mapping",
       "version": "0.1.0",
       "dependencies": {
+        "@adlign/types": "0.1.0",
         "@sentry/node": "^10.3.0",
         "dotenv": "^16.3.1",
         "openai": "^4.20.0",

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,18 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "build/**"]
     },
+    "build#@adlign/backend": {
+      "dependsOn": ["@adlign/types#build", "^build"]
+    },
+    "build#@adlign/web": {
+      "dependsOn": ["@adlign/types#build", "^build"]
+    },
+    "build#@adlign/worker-mapping": {
+      "dependsOn": ["@adlign/types#build", "^build"]
+    },
+    "build#@adlign/shopify-extension": {
+      "dependsOn": ["@adlign/types#build", "^build"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
- add `@adlign/types` as dependency for backend, web, worker-mapping apps
- have app builds wait for `@adlign/types` build via `turbo.json`

## Testing
- `npm install`
- `npm run build` *(fails: command (/workspace/Adtest/apps/shopify-extension) ... exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68b2c9cb5de08329b6025c63d5a80f62