### PR TITLE
Use turbo build/test in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint --if-present
-      - run: npm run -ws build
-      - run: npm run -ws test --if-present
+      - run: npm run build
+      - run: npm run test --if-present


### PR DESCRIPTION
## Summary
- use `npm run build` and `npm run test --if-present` in CI to leverage Turborepo dependency graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2cdf0df3083298c7e92fd508c38b5