### PR TITLE
chore: drop unused @adlign/types dependency

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@adlign/types": "0.1.0",
     "@sentry/node": "^7.0.0",
     "@sentry/profiling-node": "^1.0.0",
     "@supabase/supabase-js": "^2.38.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@adlign/types": "0.1.0",
     "@hookform/resolvers": "^3.3.2",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/apps/worker-mapping/package.json
+++ b/apps/worker-mapping/package.json
@@ -16,7 +16,6 @@
     "test:env": "tsx src/test-env.ts"
   },
   "dependencies": {
-    "@adlign/types": "0.1.0",
     "@sentry/node": "^10.3.0",
     "dotenv": "^16.3.1",
     "openai": "^4.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "name": "@adlign/backend",
       "version": "0.1.0",
       "dependencies": {
-        "@adlign/types": "0.1.0",
         "@sentry/node": "^7.0.0",
         "@sentry/profiling-node": "^1.0.0",
         "@supabase/supabase-js": "^2.38.0",
@@ -168,7 +167,6 @@
       "name": "@adlign/web",
       "version": "0.0.0",
       "dependencies": {
-        "@adlign/types": "0.1.0",
         "@hookform/resolvers": "^3.3.2",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -212,7 +210,6 @@
       "name": "@adlign/worker-mapping",
       "version": "0.1.0",
       "dependencies": {
-        "@adlign/types": "0.1.0",
         "@sentry/node": "^10.3.0",
         "dotenv": "^16.3.1",
         "openai": "^4.20.0",
@@ -18160,9 +18157,6 @@
     "packages/sdk": {
       "name": "@adlign/sdk",
       "version": "0.1.0",
-      "dependencies": {
-        "@adlign/types": "^0.1.0"
-      },
       "devDependencies": {
         "@types/node": "^20.8.0",
         "@typescript-eslint/eslint-plugin": "^6.9.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,9 +11,6 @@
     "type-check": "tsc --noEmit",
     "test": "tsx test-sdk.ts"
   },
-  "dependencies": {
-    "@adlign/types": "^0.1.0"
-  },
   "devDependencies": {
     "@types/node": "^20.8.0",
     "typescript": "^5.3.0",


### PR DESCRIPTION
## Summary
- remove @adlign/types from backend, web, worker-mapping, and sdk packages to stop npm from trying to fetch unpublished workspace
- update lockfile

## Testing
- `npm test -w @adlign/backend`
- `npm test -w @adlign/worker-mapping`
- `npm test -w @adlign/sdk`


------
https://chatgpt.com/codex/tasks/task_e_68b2c4964710832985df74169e606ce9